### PR TITLE
End output with newline

### DIFF
--- a/combinedgen/combinedgen.go
+++ b/combinedgen/combinedgen.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"log"
+	"net/http"
 )
 
 func main() {

--- a/combinedgen/combinedgen.go
+++ b/combinedgen/combinedgen.go
@@ -18,6 +18,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	number := "42"
 
 	// To trim whitespace from the strings,
-	// add "strings" to import and use string.TrimSpace("gopher\n")
+	// add "strings" to import and use strings.TrimSpace("gopher\n")
 	fmt.Fprintf(w, "%s-%s\n", name, number)
 }

--- a/combinedgen/combinedgen.go
+++ b/combinedgen/combinedgen.go
@@ -17,5 +17,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	// Call numbergen
 	number := "42"
 
-	fmt.Fprintf(w, "%s-%s", name, number)
+	// To trim whitespace from the strings,
+	// add "strings" to import and use string.TrimSpace("gopher\n")
+	fmt.Fprintf(w, "%s-%s\n", name, number)
 }

--- a/namegen/namegen.go
+++ b/namegen/namegen.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
-	"time"
-	"net/http"
 	"log"
+	"math/rand"
+	"net/http"
+	"time"
 )
 
 var (

--- a/namegen/namegen.go
+++ b/namegen/namegen.go
@@ -31,5 +31,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	randsrc := rand.NewSource(time.Now().UnixNano())
 	rnd := rand.New(randsrc)
 	name := animals[rnd.Intn(len(animals))]
-	fmt.Fprintf(w, name)
+	fmt.Fprintf(w, "%s\n", name)
 }

--- a/numbergen/numbergen.go
+++ b/numbergen/numbergen.go
@@ -16,5 +16,5 @@ func main() {
 func handler(w http.ResponseWriter, r *http.Request) {
 	randsrc := rand.NewSource(time.Now().UnixNano())
 	rnd := rand.New(randsrc)
-	fmt.Fprintf(w, "%d", rnd.Intn(100))
+	fmt.Fprintf(w, "%d\n", rnd.Intn(100))
 }

--- a/numbergen/numbergen.go
+++ b/numbergen/numbergen.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
-	"time"
-	"net/http"
 	"log"
+	"math/rand"
+	"net/http"
+	"time"
 )
 
 func main() {


### PR DESCRIPTION
Just a pet peeve I have. When running `curl $(get ip of host):8080` as per instructions, it's nice to get a newline in there.

I added a comment on how to trim them to the `combinedgen` code, so people don't have to struggle with that during the workshop.